### PR TITLE
Expose interpretOptions so that custom HasInterpretOptions instances can be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1
+
+- Expose HasInterpretOptions(interpretOptions) so that custom instances of HasInterpretOptions can be used.
+
 # 0.3
 
 - Use `dhall ==1.29`

--- a/servant-dhall.cabal
+++ b/servant-dhall.cabal
@@ -31,15 +31,15 @@ source-repository head
 library
   exposed-modules:  Servant.Dhall
   build-depends:
-      base           >=4.9      && <4.14
+      base           >=4.9      && <4.15
     , base-compat    >=0.10.1   && <0.12
     , bytestring     >=0.10.4.0 && <0.11
-    , dhall          >=1.29.0   && <1.31
+    , dhall          >=1.29.0   && <1.37
     , either         >=5.0.1.1  && <5.1
     , http-media     >=0.7.1.2  && <0.9
-    , megaparsec     >=7.0.4    && <8.1
+    , megaparsec     >=7.0.4    && <10.0
     , prettyprinter  >=1.5.1    && <1.7
-    , servant        >=0.17     && <0.18
+    , servant        >=0.17     && <0.19
     , text           >=1.2.3.0  && <1.3
 
   hs-source-dirs:   src
@@ -59,7 +59,7 @@ test-suite example
     , http-media
     , servant
     , servant-dhall
-    , servant-server  >=0.12     && <0.18
+    , servant-server  >=0.12     && <0.19
     , wai             >=3.0.3.0  && <3.3
     , warp            >=3.0.13.1 && <3.4
 

--- a/servant-dhall.cabal
+++ b/servant-dhall.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               servant-dhall
-version:            0.3
+version:            0.3.1
 synopsis:           Servant Dhall content-type
 description:
   Servant Dhall bindings.

--- a/servant-dhall.cabal
+++ b/servant-dhall.cabal
@@ -34,7 +34,7 @@ library
       base           >=4.9      && <4.14
     , base-compat    >=0.10.1   && <0.12
     , bytestring     >=0.10.4.0 && <0.11
-    , dhall          >=1.29.0   && <1.30
+    , dhall          >=1.29.0   && <1.31
     , either         >=5.0.1.1  && <5.1
     , http-media     >=0.7.1.2  && <0.9
     , megaparsec     >=7.0.4    && <8.1

--- a/src/Servant/Dhall.hs
+++ b/src/Servant/Dhall.hs
@@ -18,7 +18,7 @@
 module Servant.Dhall (
     DHALL,
     DHALL',
-    HasInterpretOptions,
+    HasInterpretOptions(..),
     DefaultInterpretOptions,
     ) where
 


### PR DESCRIPTION
The point of `HasInterpretOptions` would appear to be that you can implement your own instance of it. But it is impossible to implement a custom `HasInterpretOptions` instance because `interpretOptions` is not exposed.